### PR TITLE
made stations an optional argument and added error handling if neither stations or customlocations are specified

### DIFF
--- a/OTSO/Cone.py
+++ b/OTSO/Cone.py
@@ -1,10 +1,14 @@
-def cone(Stations, customlocations=[], startaltitude=20,minaltitude=20,zenith=0,azimuth=0,maxdistance=100,maxtime=0,
+def cone(Stations=[], customlocations=[], startaltitude=20,minaltitude=20,zenith=0,azimuth=0,maxdistance=100,maxtime=0,
            serverdata="OFF",livedata="OFF",vx=-500,vy=0,vz=0,by=5,bz=5,density=1,pdyn=0,Dst=0,
            G1=0,G2=0,G3=0,W1=0,W2=0,W3=0,W4=0,W5=0,W6=0,kp=0,Anum=1,anti="YES",year=2024,
            month=1,day=1,hour=12,minute=0,second=0,internalmag="IGRF",externalmag="TSY89",
            intmodel="Boris",startrigidity=20,endrigidity=0,rigiditystep=0.01,
            coordsystem="GEO",gyropercent=15,magnetopause="Kobel",corenum=1,g=None,h=None):
     from .Parameters.functions import otso_cone
+
+    # Check if both Stations and customlocations are empty
+    if not Stations and not customlocations:
+        raise ValueError("At least one station or custom location must be provided. Both Stations and customlocations cannot be empty.")
     
     arguments = locals()
     for arg in arguments:


### PR DESCRIPTION
I didn't realise that you could specify custom locations as an optional argument (I tried to put just the custom locations in, and was getting an error) - at the moment it seems like a neutron monitor station has to be included even if you only want to perform calculations at the NM location. This modification changes it so that the neutron monitor station is also an optional argument, but that an error is raised if you don't at least specify a neutron monitor or a custom location.