### PR TITLE
Fix argument name in coordinate transformation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ if __name__ == '__main__':
     lat_lon_alt_list = [[10,10,10]] # [[Latitude,Longitude,Altitude]]
     date_list = [datetime.datetime(2000,10,12,8)] # [dates]
     
-    Coords = OTSO.coordtrans(Locations=lat_lon_alt_list,Dates=date_list,CoordIN="GEO",CoordOUT="GSM",corenum=1)
+    Coords = OTSO.coordtrans(Locations=lat_lon_alt_list,dates=date_list,CoordIN="GEO",CoordOUT="GSM",corenum=1)
 
     print(Coords[0]) # dataframe output of converted coordinates
     print(Coords[1]) # text output detailing the initial and final conversion coordinate system


### PR DESCRIPTION
This corrects the optional argument `dates` in the coordinate transformation example when using the `OTSO.coordtrans` class.